### PR TITLE
PB-15: add info buttons to config pages

### DIFF
--- a/InfoHover.swift
+++ b/InfoHover.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct InfoButtonView: View {
     let message: String
+    let buttonSize: CGFloat
+    let title: String
     @State private var showingAlert = false
 
     var body: some View {
@@ -16,13 +18,13 @@ struct InfoButtonView: View {
             showingAlert = true
         }) {
             Image(systemName: "info.circle")
-                .font(.system(size: 30))
+                .font(.system(size: buttonSize))
                 .foregroundColor(.blue)
                 .padding()
         }
         .alert(isPresented: $showingAlert) {
             Alert(
-                title: Text("Description"),
+                title: Text(title),
                 message: Text(message),
                 dismissButton: .default(Text("OK"))
             )

--- a/posturebest/Components/ConfigureAlertsTab.swift
+++ b/posturebest/Components/ConfigureAlertsTab.swift
@@ -13,6 +13,8 @@ struct ConfigureAlertsTab: View {
     @State private var standingFreqState: String = "15"
     @State private var postureFreqState: String = "5"
     let postureOpts = ["5", "10", "15", "20", "25", "30"]
+    let postureInfo = "This configuration will set how often the vest will alert you that your posture is not optimal."
+    let standingInfo = "This configuration will set how often the vest will alert you to stand up to improve movement throughout the day."
         
     // Stnading reminders in hours and minutes
     let hours = Array(0...5).map { String($0) }
@@ -35,7 +37,9 @@ struct ConfigureAlertsTab: View {
                     .font(.headline)
                     .foregroundStyle(Color(hex: "#374663"))
                     .padding(.top, 20)
-                // add i hover
+
+                InfoButtonView(message: standingInfo, buttonSize: 15, title: "Standing Reminders").offset(x: -30, y: 20)
+                
                 
                 Picker("Select Time", selection: $selectedTime) {
                     ForEach(timeOptions, id: \.self) { time in
@@ -48,18 +52,19 @@ struct ConfigureAlertsTab: View {
                 
             }.padding(.top, 0)
             HStack {
-                Text("Posture Reminder Frequency (mins)")
+                Text("Posture Reminder \nFrequency (mins)")
                     .font(.headline)
                     .foregroundStyle(Color(hex: "#374663"))
                     .padding(.top, 20)
-                // add i hover
+               
+                InfoButtonView(message: postureInfo, buttonSize: 15, title: "Posture Reminders").offset(x: -27, y: 20)
                 
                 Picker("Select Frequency", selection: $postureFreqState) {
                     ForEach(postureOpts, id: \.self) { option in
                         Text(option).tag(option)
                     }
                 }
-                .pickerStyle(WheelPickerStyle()).frame(height: 100).frame(width: 100)
+                .pickerStyle(WheelPickerStyle()).frame(height: 100).frame(width: 100).offset(x: 5)
                 
             }.padding(.top, 0)
             

--- a/posturebest/Components/ConfigureDeviceTab.swift
+++ b/posturebest/Components/ConfigureDeviceTab.swift
@@ -9,21 +9,28 @@ import Foundation
 import SwiftUI
 
 struct ConfigureDeviceTab: View {
+    let vestConfigInfo = "Follow the steps to sync the Posture Vest to you app."
+    let instructions = "1. Ensure your device is on and connected to the PostureBest app via bluetooth. \n2. Stand with your feet hip-width apart and toes pointing forward. \n3. Straighten back, neck and align shoulders to desired position. \n4. Hold position and press the configure button."
+    let note = "Note: Please hold position for about 5 seconds while the device is being configured."
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
-            Text("Welcome to Vest Configuration!")
+            HStack {
+                Text("Welcome to Vest Configuration!")
                 .font(.headline)
                 .foregroundStyle(Color(hex: "#374663"))
                 .padding(.bottom, 10)
-            // add i hover next to vest config
+                
+                InfoButtonView(message: vestConfigInfo, buttonSize: 15, title: "Vest Configuration").offset(x: -20, y: -5)
+            }
             
-            Text("1. Ensure your device is on and connected to the      PostureBest app via bluetooth. \n2. Stand with your feet hip-width apart and toes pointing forward. \n3. Straighten back, neck and align shoulders to desired position. \n4. Hold position and press the configure button.")
+            Text(instructions)
                 .font(.subheadline)
                 .multilineTextAlignment(.leading)
                 .foregroundStyle(Color(hex: "#374663"))
                 .padding(.bottom, 50)
             
-            Text("Note: Please hold position for about 5 seconds while the device is being configured.")
+            Text(note)
                 .font(.subheadline)
                 .multilineTextAlignment(.leading)
                 .foregroundStyle(Color(hex: "#374663"))

--- a/posturebest/Views/HomeView.swift
+++ b/posturebest/Views/HomeView.swift
@@ -54,7 +54,7 @@ struct HomeView: View {
                             HStack {
                                 Spacer()
                                 VStack {
-                                    InfoButtonView(message: "This is a three-dimensional model of your torso, displaying areas of concern in your posture (red sensors).")
+                                    InfoButtonView(message: "This is a three-dimensional model of your torso, displaying areas of concern in your posture (red sensors).", buttonSize: 30, title: "Description")
                                 }
                             }
                         }


### PR DESCRIPTION
added info buttons to
- the device tab 
- both of the timers on the alerts tab

updated hover button to be customizable:
- input size
- input title