### PR TITLE
PB-24: adding bluetooth to user profile page

### DIFF
--- a/posturebest/ContentView.swift
+++ b/posturebest/ContentView.swift
@@ -19,11 +19,6 @@ struct ContentView: View {
                 .tabItem {
                     Label("Configurations", systemImage: "gear")
                 }
-            
-//            BluetoothDevicesView()
-//                .tabItem {
-//                    Label("Bluetooth", systemImage: "wifi")
-//                }
 
             UserProfileView()
                 .tabItem {

--- a/posturebest/ContentView.swift
+++ b/posturebest/ContentView.swift
@@ -20,10 +20,10 @@ struct ContentView: View {
                     Label("Configurations", systemImage: "gear")
                 }
             
-            BluetoothDevicesView()
-                .tabItem {
-                    Label("Bluetooth", systemImage: "wifi")
-                }
+//            BluetoothDevicesView()
+//                .tabItem {
+//                    Label("Bluetooth", systemImage: "wifi")
+//                }
 
             UserProfileView()
                 .tabItem {

--- a/posturebest/Views/BluetoothDevicesView.swift
+++ b/posturebest/Views/BluetoothDevicesView.swift
@@ -26,6 +26,7 @@ func rssiColor(for rssi: Int?) -> Color {
 
 struct BluetoothDevicesView: View {
     @StateObject var bleManager = BLEManager()
+    @Binding var showHeader: Bool
 
     var body: some View {
         VStack (spacing: 10) {
@@ -33,6 +34,12 @@ struct BluetoothDevicesView: View {
                 .font(.largeTitle)
                 .foregroundStyle(Color(hex: "#374663"))
                 .frame(maxWidth: .infinity, alignment: .center)
+                .onAppear {
+                                showHeader = false
+                            }
+                            .onDisappear {
+                                showHeader = true
+                            }
 
             List(bleManager.periperals) { peripheral in
                 if peripheral.name != "Unknown" {
@@ -102,7 +109,8 @@ struct BluetoothDevicesView: View {
 }
 
 struct BluetoothDevicesView_Previews: PreviewProvider {
+    @State static var showHeader = false
     static var previews: some View {
-        BluetoothDevicesView()
+        BluetoothDevicesView(showHeader: $showHeader)
     }
 }

--- a/posturebest/Views/UserProfileView.swift
+++ b/posturebest/Views/UserProfileView.swift
@@ -36,7 +36,7 @@ struct UserProfileView: View {
             NavigationView {
                 List {
 //                    Section(header: Text("My Device")) {
-//                        NavigationLink(destination: BluetoothDevicesView(showHeader: $showHeader)) {
+//                        NavigationLink(destination: MyDeviceView(showHeader: $showHeader)) {
 //                            Text("deviceName || disconnected")
 //                        }
 //                    }
@@ -45,11 +45,11 @@ struct UserProfileView: View {
                         NavigationLink(destination: BluetoothDevicesView(showHeader: $showHeader)) {
                             Text("Connect to Bluetooth Device")
                         }
-//                        NavigationLink(destination: BluetoothDevicesView(showHeader: $showHeader)) {
+//                        NavigationLink(destination: AccountInformationView(showHeader: $showHeader)) {
 //                            Text("Account Information")
 //                        }
-//                        NavigationLink(destination: BluetoothDevicesView(showHeader: $showHeader)) {
-//                            Text("User Settings")
+//                        NavigationLink(destination: AppSettings(showHeader: $showHeader)) {
+//                            Text("App Settings")
 //                        }
                     }
                     

--- a/posturebest/Views/UserProfileView.swift
+++ b/posturebest/Views/UserProfileView.swift
@@ -9,15 +9,56 @@ import Foundation
 import SwiftUI
 
 struct UserProfileView: View {
+    // add username
+    // add device name
+    
+    @State private var showHeader = true
     var body: some View {
         VStack {
+        if (showHeader) {
             Text("User Profile Page")
                 .font(.largeTitle)
+                .foregroundStyle(Color(hex: "#374663"))
                 .padding()
+            
+                HStack{
+                    Circle()
+                        .fill()
+                        .frame(width: 60, height: 60)
+                    
+                    Text("username")
+                        .font(.title3)
+                }
+                .foregroundStyle(Color(hex: "#374663"))
+                .offset(x: -100)
+            }
+            
+            NavigationView {
+                List {
+//                    Section(header: Text("My Device")) {
+//                        NavigationLink(destination: BluetoothDevicesView(showHeader: $showHeader)) {
+//                            Text("deviceName || disconnected")
+//                        }
+//                    }
+
+                    Section() {
+                        NavigationLink(destination: BluetoothDevicesView(showHeader: $showHeader)) {
+                            Text("Connect to Bluetooth Device")
+                        }
+//                        NavigationLink(destination: BluetoothDevicesView(showHeader: $showHeader)) {
+//                            Text("Account Information")
+//                        }
+//                        NavigationLink(destination: BluetoothDevicesView(showHeader: $showHeader)) {
+//                            Text("User Settings")
+//                        }
+                    }
+                    
+                }
+            }
+           
             Spacer()
         }
         .navigationTitle("Profile")
-        .background(Color.cyan.opacity(0.1).ignoresSafeArea())
     }
 }
 


### PR DESCRIPTION
- Added navigation link in `UserProfileView` for `BluetoothDevicesView`, shown below.
- These pictures include the future options for the User Settings page as well
<img width="338" alt="IMG_8615" src="https://github.com/user-attachments/assets/3d1dbc1b-f1f9-4023-80cc-72acc18a4dc9">

Upon clicking `Connect Bluetooth Devices`, directed here:
<img width="352" alt="IMG_9968" src="https://github.com/user-attachments/assets/110a0852-8854-40d8-9520-5fbcfd4425e8">

IMPORTANT NOTES:
- I commented out all options that are not `Connect to Bluetooth Device` because those pages do not exist yet. However, I wrote the code for the navigation so the pages can be added easily once we create them.
- We will need to add the variable device name and variable username. 
 --- right now just hardcoded in (can be seen in `deviceName || Disconnected` and `username`
- the circle will need to be replaced with an icon of man/woman/avatar
- do we want to add icons to the options?